### PR TITLE
siquery-rs: set RUSTFLAGS on Windows for crt-static building

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -221,6 +221,8 @@ stages:
 
           - script: cargo build --target i686-pc-windows-msvc --release
             displayName: Building siquery
+            env:
+              RUSTFLAGS: -Ctarget-feature=+crt-static
 
           - script: signtool sign /n Devolutions /fd sha256 /tr http://timestamp.comodoca.com/?td=sha256 /td sha256 /v $(Build.Repository.LocalPath)/target/i686-pc-windows-msvc/release/siquery.exe
 

--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -173,6 +173,8 @@ stages:
 
           - script: cargo build --target x86_64-pc-windows-msvc --release
             displayName: Building siquery
+            env:
+              RUSTFLAGS: -Ctarget-feature=+crt-static
 
           - script: signtool sign /n Devolutions /fd sha256 /tr http://timestamp.comodoca.com/?td=sha256 /td sha256 /v $(Build.Repository.LocalPath)/target/x86_64-pc-windows-msvc/release/siquery.exe
 


### PR DESCRIPTION
Completely untested, but we weren't setting RUSTFLAGS=“-Ctarget-feature=+crt-static” so no wonder that siquery.exe ended up linking against VCRUNTIME140.dll.