### PR TITLE
Update rusqlite to 0.23

### DIFF
--- a/azure-pipelines.yaml
+++ b/azure-pipelines.yaml
@@ -171,12 +171,12 @@ stages:
               Import-PfxCertificate -FilePath $(signingCert.secureFilePath) -CertStoreLocation Cert:\CurrentUser\My -Password $secureString
             displayName: Import signing certificate
 
-          - script: cargo build --target x86_64-pc-windows-msvc --release
+          - powershell: cargo build --target x86_64-pc-windows-msvc --release
             displayName: Building siquery
             env:
               RUSTFLAGS: -Ctarget-feature=+crt-static
 
-          - script: signtool sign /n Devolutions /fd sha256 /tr http://timestamp.comodoca.com/?td=sha256 /td sha256 /v $(Build.Repository.LocalPath)/target/x86_64-pc-windows-msvc/release/siquery.exe
+          - powershell: signtool sign /n Devolutions /fd sha256 /tr http://timestamp.comodoca.com/?td=sha256 /td sha256 /v $(Build.Repository.LocalPath)/target/x86_64-pc-windows-msvc/release/siquery.exe
 
           - task: ArchiveFiles@2
             inputs:
@@ -221,12 +221,12 @@ stages:
               Import-PfxCertificate -FilePath $(signingCert.secureFilePath) -CertStoreLocation Cert:\CurrentUser\My -Password $secureString
             displayName: Import signing certificate
 
-          - script: cargo build --target i686-pc-windows-msvc --release
+          - powershell: cargo build --target i686-pc-windows-msvc --release
             displayName: Building siquery
             env:
               RUSTFLAGS: -Ctarget-feature=+crt-static
 
-          - script: signtool sign /n Devolutions /fd sha256 /tr http://timestamp.comodoca.com/?td=sha256 /td sha256 /v $(Build.Repository.LocalPath)/target/i686-pc-windows-msvc/release/siquery.exe
+          - powershell: signtool sign /n Devolutions /fd sha256 /tr http://timestamp.comodoca.com/?td=sha256 /td sha256 /v $(Build.Repository.LocalPath)/target/i686-pc-windows-msvc/release/siquery.exe
 
           - task: ArchiveFiles@2
             inputs:

--- a/siquery/Cargo.toml
+++ b/siquery/Cargo.toml
@@ -54,7 +54,7 @@ libc = "0.2"
 nix = "0.11.0"
 
 [dependencies.rusqlite]
-version = "^0.14"
+version = "0.23"
 features = ["vtab", "bundled"]
 
 [dependencies.proxy_cfg]

--- a/siquery/src/html.rs
+++ b/siquery/src/html.rs
@@ -20,25 +20,23 @@ pub fn map(values: &mut Rows) -> Vec<Vec<String>> {
     let mut table: Vec<Vec<String>> = Vec::new();
     let mut row: Vec<String> = Vec::new();
     loop {
-        if let Some(v) = values.next() {
-            if let Some(res) = v.ok() {
-                for i in 0..res.column_count() {
-                    let val = Value::data_type(&res.get(i));
-                    match val {
-                        Type::Real | Type::Integer => {
-                            row.push(res.get::<usize, i64>(i).to_string());
-                        },
-                        Type::Text => {
-                            row.push(res.get::<usize, String>(i))
-                        },
-                        _ => {
-                            // Do nothing.
-                        }
+        if let Ok(Some(res)) = values.next() {
+            for i in 0..res.column_count() {
+                let val = Value::data_type(&res.get_unwrap(i));
+                match val {
+                    Type::Real | Type::Integer => {
+                        row.push(res.get_unwrap::<usize, i64>(i).to_string());
+                    },
+                    Type::Text => {
+                        row.push(res.get_unwrap::<usize, String>(i))
+                    },
+                    _ => {
+                        // Do nothing.
                     }
                 }
-                table.push(row);
-                row = Vec::new();
             }
+            table.push(row);
+            row = Vec::new();
         } else {
             break
         }

--- a/siquery/src/printer.rs
+++ b/siquery/src/printer.rs
@@ -17,26 +17,24 @@ pub fn print_csv(columns: Vec<String>, values: &mut Rows) {
     //write header first
     wtr.write_record(columns).expect("could not write columns");
     loop {
-        if let Some(v) = values.next(){
-            if let Some (res) = v.ok() {
-                for i in 0..res.column_count() {
-                    let val = Value::data_type(&res.get(i));
-                    match val {
-                        Type::Real | Type::Integer => {
-                            row.push(res.get::<usize,i64>(i).to_string());
-                        },
-                        Type::Text => {
-                            row.push(res.get::<usize,String>(i))
-                        },
-                        _ => {
-                            // Do nothing.
-                        }
+        if let Ok(Some(res)) = values.next(){
+            for i in 0..res.column_count() {
+                let val = Value::data_type(&res.get_unwrap(i));
+                match val {
+                    Type::Real | Type::Integer => {
+                        row.push(res.get_unwrap::<usize,i64>(i).to_string());
+                    },
+                    Type::Text => {
+                        row.push(res.get_unwrap::<usize,String>(i))
+                    },
+                    _ => {
+                        // Do nothing.
                     }
                 }
-                // write row values
-                wtr.write_record(row).expect("could not write row");;
-                row = Vec::new();
             }
+            // write row values
+            wtr.write_record(row).expect("could not write row");;
+            row = Vec::new();
         } else {
             break
         }
@@ -50,25 +48,23 @@ pub fn print_pretty(columns: Vec<String>, values: &mut Rows) {
     //write header first
     table.set_titles(columns.iter().collect());
     loop {
-        if let Some(v) = values.next(){
-            if let Some (res) = v.ok() {
-                for i in 0..res.column_count() {
-                    let val = Value::data_type(&res.get(i));
-                    match val {
-                        Type::Real | Type::Integer => {
-                            row.add_cell(Cell::new(&res.get::<usize,i64>(i).to_string()));
-                        },
-                        Type::Text => {
-                            row.add_cell(Cell::new(&res.get::<usize,String>(i)))
-                        },
-                        _ => {
-                            // Do nothing.
-                        }
+        if let Ok(Some(res)) = values.next(){
+            for i in 0..res.column_count() {
+                let val = Value::data_type(&res.get_unwrap(i));
+                match val {
+                    Type::Real | Type::Integer => {
+                        row.add_cell(Cell::new(&res.get_unwrap::<usize,i64>(i).to_string()));
+                    },
+                    Type::Text => {
+                        row.add_cell(Cell::new(&res.get_unwrap::<usize,String>(i)))
+                    },
+                    _ => {
+                        // Do nothing.
                     }
                 }
-                table.add_row(row);
-                row = Row::empty();
             }
+            table.add_row(row);
+            row = Row::empty();
         } else {
             break
         }
@@ -76,15 +72,13 @@ pub fn print_pretty(columns: Vec<String>, values: &mut Rows) {
     println!("{}", table);
 }
 
-pub fn print_json (table_name: String, col_names: &Vec<String>, values: &mut Rows) -> Vec<Map<String,serdValue>> {
+pub fn print_json(table_name: String, col_names: &Vec<String>, values: &mut Rows) -> Vec<Map<String,serdValue>> {
     let mut writer: Vec<Map<String,serdValue>> = Vec::new();
     let mut _value: Map<String, serdValue> = Map::new();
     loop {
-        if let Some(v) = values.next() {
-            if let Some(res) = v.ok() {
-                _value = format_to_json(&col_names, &res);
-                writer.push(_value);
-            }
+        if let Ok(Some(res)) = values.next() {
+            _value = format_to_json(&col_names, &res);
+            writer.push(_value);
         } else {
             break
         }
@@ -96,27 +90,27 @@ pub fn print_json (table_name: String, col_names: &Vec<String>, values: &mut Row
     writer
 }
 
-fn format_to_json (col_names: &Vec<String>, row_value : &RusqliteRow) -> Map<String, serdValue> {
+fn format_to_json(col_names: &Vec<String>, row_value : &RusqliteRow) -> Map<String, serdValue> {
     let mut value_json: Map<String, serdValue> = Map::new();
-    match Value::data_type(&row_value.get(0)) {
+    match Value::data_type(&row_value.get_unwrap(0)) {
         Type::Real | Type::Integer => {
-            value_json.insert(col_names[0].clone(),json!(row_value.get::<usize,i64>(0)));
+            value_json.insert(col_names[0].clone(),json!(row_value.get_unwrap::<usize,i64>(0)));
         },
         Type::Text => {
-            value_json.insert(col_names[0].clone(),json!(row_value.get::<usize,String>(0)));
+            value_json.insert(col_names[0].clone(),json!(row_value.get_unwrap::<usize,String>(0)));
         },
         _ => {
             // Do nothing.
         }
     }
     for i in 1..row_value.column_count() {
-        let v: Value = row_value.get(i);
+        let v: Value = row_value.get_unwrap(i);
         match Value::data_type(&v) {
             Type::Real | Type::Integer => {
-                value_json.insert(col_names[i].clone(),json!(row_value.get::<usize,i64>(i)));
+                value_json.insert(col_names[i].clone(),json!(row_value.get_unwrap::<usize,i64>(i)));
             },
             Type::Text => {
-                value_json.insert(col_names[i].clone(),json!(row_value.get::<usize,String>(i)));
+                value_json.insert(col_names[i].clone(),json!(row_value.get_unwrap::<usize,String>(i)));
             },
             _ => {
                 // Do nothing.

--- a/siquery/src/query.rs
+++ b/siquery/src/query.rs
@@ -1,6 +1,6 @@
 use crate::tables::*;
 use crate::vtab::*;
-use rusqlite::{version_number, Connection, Error};
+use rusqlite::{version_number, Connection, Error, NO_PARAMS};
 use rusqlite::types::Value;
 use crate::printer::*;
 use crate::html::print_html;
@@ -603,7 +603,7 @@ pub fn execute_query(db: &Connection, query: &str, table_name: String, flag: u8)
             }
             table_result.push(row);
 
-            let mut response = statement_res.query(&[]).unwrap();
+            let mut response = statement_res.query(NO_PARAMS).unwrap();
             if flag == 2 {
                 print_csv(col_name_internal, &mut response);
             } else if flag == 3 {


### PR DESCRIPTION
This pull request updates the rusqlite dependency to version 0.23, some security issues were fixed.

https://rustsec.org/advisories/RUSTSEC-2020-0014.html
https://github.com/rusqlite/rusqlite/releases/tag/0.23.0

rusqlite contains a number of breaking changes since version 0.14, to make the review easier here are the changes I applied.

`The trait implementation of VTab and VTabCursor is now unsafe`

The first member of structs implementing these traits must be sqlite3_vtab/sqlite3_vtab_cursor and they must be repr(C). I verified that these conditions are met.

`Rows::next returns Result<Option<&Row<'_>>> instead of Option<Result<Row<...>>>`

The pattern matching was changed to reflect this change, I also merged both match together to remove a layer of nesting.

`Row::get is now Row::get_checked, the previous method is now named Row::get_unwrap`

I replaced the calls to `get` with `get_unwrap`. The conditions were the code could panic shouldn't happen.

https://docs.rs/rusqlite/0.23.1/rusqlite/struct.Row.html#method.get_unwrap