### PR TITLE
Update rustqlite to 0.28

### DIFF
--- a/siquery/Cargo.toml
+++ b/siquery/Cargo.toml
@@ -54,7 +54,7 @@ libc = "0.2"
 nix = "0.11.0"
 
 [dependencies.rusqlite]
-version = "0.25"
+version = "0.28"
 features = ["vtab", "bundled"]
 
 [dependencies.proxy_cfg]

--- a/siquery/src/html.rs
+++ b/siquery/src/html.rs
@@ -16,12 +16,12 @@ use crate::tables::{
     SystemInfoData
 };
 
-pub fn map(values: &mut Rows) -> Vec<Vec<String>> {
+pub fn map(values: &mut Rows, column_count: usize) -> Vec<Vec<String>> {
     let mut table: Vec<Vec<String>> = Vec::new();
     let mut row: Vec<String> = Vec::new();
     loop {
         if let Ok(Some(res)) = values.next() {
-            for i in 0..res.column_count() {
+            for i in 0..column_count {
                 let val = Value::data_type(&res.get_unwrap(i));
                 match val {
                     Type::Real | Type::Integer => {
@@ -44,8 +44,8 @@ pub fn map(values: &mut Rows) -> Vec<Vec<String>> {
     table
 }
 
-pub fn print_html(columns: Vec<String>, values: &mut Rows, query: &str) {
-    let map = map(values);
+pub fn print_html(columns: Vec<String>, values: &mut Rows, query: &str, column_count: usize) {
+    let map = map(values, column_count);
     let table_name = query.split(' ').collect::<Vec<&str>>();
     let hostname = format!(
         "{}",

--- a/siquery/src/query.rs
+++ b/siquery/src/query.rs
@@ -603,15 +603,16 @@ pub fn execute_query(db: &Connection, query: &str, table_name: String, flag: u8)
             }
             table_result.push(row);
 
+            let column_count = statement_res.column_count();
             let mut response = statement_res.query([]).unwrap();
             if flag == 2 {
-                print_csv(col_name_internal, &mut response);
+                print_csv(col_name_internal, &mut response, column_count);
             } else if flag == 3 {
-                print_html(col_name_internal, &mut response, query);
+                print_html(col_name_internal, &mut response, query, column_count);
             } else if flag == 1 {
-                writer = print_json(table_name, &col_name_internal, &mut response);
+                writer = print_json(table_name, &col_name_internal, &mut response, column_count);
             } else {
-                print_pretty(col_name_internal, &mut response);
+                print_pretty(col_name_internal, &mut response, column_count);
             }
         },
         Err(e) =>

--- a/siquery/src/vtab.rs
+++ b/siquery/src/vtab.rs
@@ -1,6 +1,6 @@
 use rusqlite::vtab::{
     sqlite3_vtab, sqlite3_vtab_cursor, Context, IndexInfo,
-    VTab, VTabConnection, VTabCursor, Values, read_only_module,
+    VTab, VTabConnection, VTabCursor, VTabKind, Values, read_only_module,
     dequote, Module, CreateVTab};
 
 use rusqlite::types::*;
@@ -85,10 +85,13 @@ unsafe impl VTab<'_> for SiqueryTab {
         Ok(())
     }
 
-    fn open(&self) -> Result<SiqueryTabCursor> {Ok(SiqueryTabCursor::default())}
+    fn open(&mut self) -> Result<SiqueryTabCursor> {Ok(SiqueryTabCursor::default())}
 }
 
-impl CreateVTab<'_> for SiqueryTab {}
+impl CreateVTab<'_> for SiqueryTab {
+    const KIND: VTabKind = VTabKind::Default;
+
+}
 
 #[derive(Default)]
 #[repr(C)]


### PR DESCRIPTION
rustqlite is updated to version 0.28 to update the bundled version of SQLite to 3.39.2 which contains a fix for CVE-2022-35737. Looking at the vulnerability writeup by TrailOfBits the impact is likely limited to a denial service.

https://sqlite.org/releaselog/3_39_2.html
https://blog.trailofbits.com/2022/10/25/sqlite-vulnerability-july-2022-library-api/